### PR TITLE
Keeping shutdown object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
-Dec 14th 2019
+Gnome extension that hides the "Power Off button" from the status area. The system can still be power off from the command line, or once the extension is disabled. The aim is to avoid users connected remotely to see the "Power off" action. Even if they cannot power off the system, better to avoid visual temptation.
 
-Hi, this is my first gnome-shell-extension.
+The aim of this extension is based on [a question raised at Ask Ubuntu](https://askubuntu.com/q/1179727/739431)
 
-Written for https://askubuntu.com/q/1179727/739431
-Tested in Ubuntu 18.04, Ubuntu 19.04 and Ubuntu 19.10
+Tested in Ubuntu 18.04, 19.04 and 19.10
 
-Instruction
-------------
-1. when you turnoff this extension, "gnome-shell" restart is required to bring the PowerOff Action Button back.
-2. So, when you turnoff this extension, Press 'Alt+F2' dialog box will open, type 'r' or 'restart' and press 'Enter'
+# How to install
 
-Installation
--------------
-1. Download the files extension.js and metadata.json
-2. keep them in "$HOME/.local/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm/" (Create the directory's as necessary) for local user.
-3. keep them in "/usr/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm/" (Create the directory's as necessary) for systemwide.
-4. Refresh the gnome-shell with Alt+F2 r Enter
-5. Enable the extension "Remove poweroff action button" with the easier way via gnome-tweaks (sudo apt install gnome-tweaks) or via command line.
+For installing locally, just run the script `install.sh local-install` from the command line. If you want to make it system wide available, use `install.sh system` instead (as root).
 
-Removal
---------
-1. simply delete the directory "RemovePoweroffActionButton@pratap.fastmail.fm" from the installed location. either "$HOME/.local/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm" or "/usr/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm"
+Once installed, you may need to restart your Gnome Shell. Use `ALT + F2` and indicate `r`.
+
+# Removal
+
+Simply delete the directory `RemovePoweroffActionButton@pratap.fastmail.fm` from the installed location, either `$HOME/.local/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm` or `/usr/share/gnome-shell/extensions/RemovePoweroffActionButton@pratap.fastmail.fm`

--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,0 @@
-function enable() { imports.ui.main.panel.statusArea.aggregateMenu._system._altSwitcher.actor.destroy(); }
-/* when you turnoff this extension, "gnome-shell" restart is required to bring the PowerOff Action Button back. */
-/* So, when you turnoff this extension, Press 'Alt+F2' dialog box will open, type 'r' or 'restart' and press 'Enter' */
-function disable() {}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ "$UID" = "0" ]; then
+  echo "This script should not be run as root"
+  exit 1
+fi
+
+NAME=RemovePoweroffActionButton\@pratap.fastmail.fm
+DEST=~/.local/share/gnome-shell/extensions/$NAME
+
+echo 'Installing...'
+if [ ! -d $DEST ]; then
+  mkdir -p $DEST
+fi
+cp -r src/* $DEST/
+
+echo 'Done'

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-if [ "$UID" = "0" ]; then
-  echo "This script should not be run as root"
-  exit 1
-fi
-
 NAME=RemovePoweroffActionButton\@pratap.fastmail.fm
-DEST=~/.local/share/gnome-shell/extensions/$NAME
+
+case "$1" in
+  "local-install" )
+    if [ "$UID" == "0" ]; then
+      echo "This script should not be run as root"
+      exit 1
+    fi
+    DEST=~/.local/share/gnome-shell/extensions/$NAME
+    ;;
+  "system" )
+    DEST=/usr/share/gnome-shell/extensions/$NAME
+    ;;
+  * )
+    echo "Use the parameter 'local-install' or 'system' (as root) for specifying a install scope"
+    exit 1
+esac
 
 echo 'Installing...'
 if [ ! -d $DEST ]; then

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,0 @@
-{
-"name": "Remove Poweroff Action Button",
-"description": "Remove Poweroff Action Button from gnome-shell's statusArea/aggregateMenu",
-"uuid": "RemovePoweroffActionButton@pratap.fastmail.fm",
-"shell-version": ["3.28", "3.32", "3.34"]
-}

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,0 +1,25 @@
+const System = imports.ui.main.panel.statusArea.aggregateMenu._system;
+
+var _powerOffItem = System._altSwitcher.actor;
+
+function init() {}
+
+function enable() {
+  if (System._actionsItem === undefined) {
+    // Gnome >= 3.33
+    System.buttonGroup.remove_child(_powerOffItem);
+  } else if (System._session === undefined) {
+    // Gnome >= 3.26
+    System._actionsItem.actor.remove_child(_powerOffItem);
+  } else {
+    System.buttonGroup.remove_child(_powerOffItem);
+  }
+}
+
+function disable() {
+  if (System._actionsItem === undefined) {
+    System.buttonGroup.add_child(_powerOffItem);
+  } else {
+    System._actionsItem.actor.add_child(_powerOffItem);
+  }
+}

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "Remove Poweroff Action Button",
+  "description": "Remove Poweroff Action Button from gnome-shell's statusArea/aggregateMenu",
+  "uuid": "RemovePoweroffActionButton@pratap.fastmail.fm",
+  "shell-version": ["3.28", "3.32", "3.34"]
+}


### PR DESCRIPTION
I've modified the code to keep the "power off" item, so the Gnome Shell does not have to be restarted when the extension is disabled.

It also includes a script for making the install process automatic and the correspond update on the Readme.